### PR TITLE
Fix not changing to port 5555

### DIFF
--- a/app/src/main/java/com/tpn/adbautoenable/AdbConfigService.java
+++ b/app/src/main/java/com/tpn/adbautoenable/AdbConfigService.java
@@ -297,7 +297,7 @@ public class AdbConfigService extends Service {
             updateStatus("Switching to port 5555...");
 
             AdbHelper adbHelper = new AdbHelper(this);
-            boolean success = adbHelper.switchToPort5555("127.0.0.1", port);  // Use localhost
+            boolean success = adbHelper.switchToPort5555(deviceIP, port);  // Use the device's own LAN IP; loopback doesn't work on all devices
 
 
             if (success) {

--- a/app/src/main/java/com/tpn/adbautoenable/WebServer.java
+++ b/app/src/main/java/com/tpn/adbautoenable/WebServer.java
@@ -277,7 +277,7 @@ public class WebServer extends NanoHTTPD {
 
     private boolean checkPort5555() {
         try {
-            Socket socket = new Socket("127.0.0.1", 5555);
+            Socket socket = new Socket(getDeviceIP(), 5555);
             socket.close();
             return true;
         } catch (Exception e) {
@@ -306,8 +306,9 @@ public class WebServer extends NanoHTTPD {
                     return;
                 }
 
+                String deviceIP = getDeviceIP();
                 Log.i(TAG, "Web API: Found ADB on port " + port + ", switching to 5555...");
-                boolean success = adbHelper.switchToPort5555("127.0.0.1", port);  // Use localhost for port 5555
+                boolean success = adbHelper.switchToPort5555(deviceIP, port);  // Use the device's own LAN IP; loopback doesn't work on all devices
 
                 if (success) {
                     Log.i(TAG, "Web API: Successfully switched to port 5555");


### PR DESCRIPTION
Fixes the "Failed to switch to port 5555" issue (#8) where switchToPort5555()
connects to 127.0.0.1 instead of the device's own LAN IP.

On my device (confirmed via manual `adb connect <device-ip>:<port>`), the
wireless-debugging ADB connect service accepts TLS connections via the LAN
IP but not via loopback — pairing and permission grant succeed, but the
self-connect step fails every time with an IOException in
AdbConnection.waitForConnection().

This patch passes the already-discovered device IP through to
switchToPort5555() in the boot flow, the manual "Switch to Port 5555 Now"
button, and the port-5555 availability check.

**Note: I've only tested this on my own device. I can't guarantee it fixes
the issue on every device/OEM, and it's possible some devices behave the
opposite way (loopback works, LAN IP doesn't). Feedback from others hitting
#8 would help confirm.**