### PR TITLE
Re-enable BootReceiver from the service when something disables it

### DIFF
--- a/app/src/main/java/com/tpn/adbautoenable/AdbConfigService.java
+++ b/app/src/main/java/com/tpn/adbautoenable/AdbConfigService.java
@@ -4,9 +4,11 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.Service;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.net.nsd.NsdManager;
 import android.net.nsd.NsdServiceInfo;
 import android.os.Bundle;
@@ -44,11 +46,37 @@ public class AdbConfigService extends Service {
         return NetworkUtils.getDeviceProtectedPrefs(this, PREFS_NAME);
     }
 
+    // Some devices disable BootReceiver behind the app's back, which takes it out
+    // of the BOOT_COMPLETED resolution set and stops the app ever starting at
+    // boot. A shell cannot undo that for an app that is not test-only, and
+    // reinstalling loses the app's adb key, but the app may set its own
+    // components, so it is repaired here on every service start.
+    private void ensureBootReceiverEnabled() {
+        try {
+            PackageManager pm = getPackageManager();
+            ComponentName receiver = new ComponentName(this, BootReceiver.class);
+            // Anything that is not enabled, rather than the one disabled state:
+            // DISABLED_USER and DISABLED_UNTIL_USED keep it out of the resolution
+            // set just as surely, and DEFAULT means the manifest value, enabled.
+            int state = pm.getComponentEnabledSetting(receiver);
+            if (state != PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+                    && state != PackageManager.COMPONENT_ENABLED_STATE_DEFAULT) {
+                pm.setComponentEnabledSetting(receiver,
+                        PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                        PackageManager.DONT_KILL_APP);
+                Log.i(TAG, "BootReceiver was disabled, re-enabled it");
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Could not check or re-enable BootReceiver", e);
+        }
+    }
+
     @Override
     public void onCreate() {
         super.onCreate();
         Log.i(TAG, "AdbConfigService onCreate() called");
         try {
+            ensureBootReceiverEnabled();
             createNotificationChannel();
             Log.i(TAG, "Notification channel created");
 


### PR DESCRIPTION
This fix worked for me. I've tested across 10 reboots including full power off from the outlet.

What follows is from Claude Opus 5:

---

This is the fix for the boot problem in #1, from the device in that report.

The set puts `BootReceiver` in the package's `disabledComponents` after every boot, which takes it out of the `BOOT_COMPLETED` resolution set, so the app is never started and Step 0 never runs:

```
$ adb shell dumpsys package com.tpn.adbautoenable
      disabledComponents:
        com.tpn.adbautoenable.BootReceiver

$ adb shell pm query-receivers --components -a android.intent.action.BOOT_COMPLETED
89 receivers found:      # com.tpn.adbautoenable is not among them
```

Nothing outside the app can undo it. `pm enable`, `pm default-state` and `pm enable --user 0` all answer `SecurityException: Shell cannot change component state` for an app that is not test-only, and `install -r` preserves the disabled state. That leaves a clean reinstall, which deletes the app's adb key along with any pairing made to it.

An app may set its own components, so this repairs the receiver in `AdbConfigService.onCreate()`. The prune on this device lands about 33ms after the receiver fires, so the app is running by then and re-arms itself for the next boot.

The check treats anything that is not `ENABLED` or `DEFAULT` as needing repair, since `DISABLED_USER` and `DISABLED_UNTIL_USED` keep a component out of the resolution set just as surely as `DISABLED`.

### Testing

Built on this branch and run on the Hisense set from #1 (`SmartTV 4K FFM`, Android 14, build `UKN2.241117.001.038`), which had never once started the app at boot before this:

- 11 recoveries, no failures: ten reboots and one hard power cut at the wall. Every one ended with the app started, wireless debugging on, and the receiver armed for the next boot.
- `BOOT_COMPLETED` reaches the app about 315s after a reboot on this device, and it reports `BootReceiver was disabled, re-enabled it` about 33ms later.
- The app's own pairing survived the hard power cut, so on this device at least, pulled power does not corrupt the stored key.

The log line only appears when a repair was actually needed, so on a device that never prunes the receiver this changes nothing.
