### PR TITLE
Add TCL autostart protection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,4 +49,6 @@ dependencies {
     implementation(libs.bouncycastle.bcprov)
     implementation(libs.bouncycastle.bcpkix)
     implementation(libs.androidx.annotation)
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.json:json:20250517")
 }

--- a/app/src/main/java/com/tpn/adbautoenable/AdbConfigService.java
+++ b/app/src/main/java/com/tpn/adbautoenable/AdbConfigService.java
@@ -119,6 +119,7 @@ public class AdbConfigService extends Service {
             );
             startForeground(1, notification);
             Log.i(TAG, "Started foreground service with notification");
+            ensureTclAutostartProtectionAsync();
             // Fix: Ensure wireless debugging is enabled on EVERY service start, not just boot events.
             enableWirelessDebuggingImmediately();
 
@@ -156,6 +157,39 @@ public class AdbConfigService extends Service {
         }
 
         return START_STICKY;
+    }
+
+    private void ensureTclAutostartProtectionAsync() {
+        new Thread(() -> {
+            TclAutostartProtection.Result policy = TclAutostartProtection.apply(
+                    getContentResolver(),
+                    getPackageName()
+            );
+            if (!policy.available) {
+                return;
+            }
+            if (!policy.success) {
+                Log.w(TAG, "TCL AppBootPolicy protection could not be applied");
+                return;
+            }
+
+            SharedPreferences prefs = getPrefs();
+            if (!prefs.getBoolean("is_paired", false)) {
+                Log.i(TAG, "TCL AppBootPolicy applied; ADB pairing is needed for AUTO_START app-op");
+                return;
+            }
+
+            int targetPort = getTargetPort();
+            AdbHelper adbHelper = new AdbHelper(this);
+            boolean allowed = adbHelper.ensureTclAutoStart(
+                    getDeviceIP(),
+                    targetPort,
+                    getPackageName()
+            );
+            if (!allowed) {
+                Log.w(TAG, "TCL AUTO_START app-op could not be verified");
+            }
+        }, "tcl-autostart-protection").start();
     }
 
     @Override

--- a/app/src/main/java/com/tpn/adbautoenable/AdbHelper.java
+++ b/app/src/main/java/com/tpn/adbautoenable/AdbHelper.java
@@ -35,6 +35,8 @@ import java.security.cert.X509Certificate;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Date;
+import java.util.Locale;
+import java.nio.charset.StandardCharsets;
 
 public class AdbHelper {
     private static final String TAG = "ADBAutoEnable";
@@ -87,6 +89,51 @@ public class AdbHelper {
             Log.e(TAG, "Connect failed", e);
             return false;
         }
+    }
+
+    public boolean ensureTclAutoStart(String host, int port, String packageName) {
+        if (executeTclAutoStart("127.0.0.1", port, packageName)) {
+            return true;
+        }
+        if (!host.equals("127.0.0.1")) {
+            Log.i(TAG, "TCL auto-start setup failed via loopback, retrying via " + host);
+            return executeTclAutoStart(host, port, packageName);
+        }
+        return false;
+    }
+
+    private boolean executeTclAutoStart(String host, int port, String packageName) {
+        try (SimpleAdbManager manager = new SimpleAdbManager(context)) {
+            manager.connect(host, port);
+            executeShell(manager, "appops set " + packageName + " AUTO_START allow");
+            String state = executeShell(manager, "appops get " + packageName + " AUTO_START");
+            boolean allowed = state.toLowerCase(Locale.ROOT).contains("allow");
+            Log.i(TAG, "TCL AUTO_START allowed: " + allowed);
+            return allowed;
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to configure TCL AUTO_START on " + host + ":" + port, e);
+            return false;
+        }
+    }
+
+    private String executeShell(SimpleAdbManager manager, String command) throws Exception {
+        StringBuilder output = new StringBuilder();
+        try (AdbStream stream = manager.openStream("shell:" + command);
+             InputStream inputStream = stream.openInputStream()) {
+            byte[] buffer = new byte[1024];
+            int bytesRead;
+            try {
+                while ((bytesRead = inputStream.read(buffer)) != -1) {
+                    output.append(new String(buffer, 0, bytesRead, StandardCharsets.UTF_8));
+                }
+            } catch (IOException e) {
+                if (!"Stream closed.".equals(e.getMessage())) {
+                    throw e;
+                }
+                Log.d(TAG, "ADB shell command completed with a closed stream");
+            }
+        }
+        return output.toString();
     }
 
     public boolean selfGrantPermission(String host, int port, String packageName, String permission) {

--- a/app/src/main/java/com/tpn/adbautoenable/TclAutostartProtection.java
+++ b/app/src/main/java/com/tpn/adbautoenable/TclAutostartProtection.java
@@ -1,0 +1,112 @@
+package com.tpn.adbautoenable;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.util.Log;
+
+import org.json.JSONArray;
+
+final class TclAutostartProtection {
+    private static final String TAG = "ADBAutoEnable";
+    private static final String MODULE = "AppBootPolicy";
+    private static final String[] AUTHORITIES = {
+            "com.tcl.providers.config",
+            "com.tcl.config.ConfigProvider"
+    };
+    private static final String[] PROJECTION = {"project_id", "config_content"};
+
+    private TclAutostartProtection() {
+    }
+
+    static Result apply(ContentResolver resolver, String packageName) {
+        for (String authority : AUTHORITIES) {
+            Uri uri = Uri.parse("content://" + authority + "/" + MODULE);
+            JSONArray policy = readPolicy(resolver, uri);
+            if (policy == null) {
+                continue;
+            }
+            if (!TclBootPolicy.supports(policy)) {
+                Log.w(TAG, "TCL AppBootPolicy schema is unsupported at " + authority);
+                return Result.unsupported(authority);
+            }
+
+            boolean changed = TclBootPolicy.protect(policy, packageName);
+            if (changed) {
+                ContentValues values = new ContentValues();
+                values.put("config_content", policy.toString());
+                try {
+                    int rows = resolver.update(uri, values, null, null);
+                    if (rows <= 0) {
+                        Log.e(TAG, "TCL AppBootPolicy update changed " + rows + " rows");
+                        return Result.failed(authority);
+                    }
+                } catch (Exception e) {
+                    Log.e(TAG, "TCL AppBootPolicy update failed at " + authority, e);
+                    return Result.failed(authority);
+                }
+            }
+
+            JSONArray verified = readPolicy(resolver, uri);
+            if (verified != null && TclBootPolicy.isProtected(verified, packageName)) {
+                Log.i(TAG, "TCL AppBootPolicy protection "
+                        + (changed ? "applied" : "verified") + " at " + authority);
+                return Result.success(authority, changed);
+            }
+
+            Log.e(TAG, "TCL AppBootPolicy verification failed at " + authority);
+            return Result.failed(authority);
+        }
+
+        Log.i(TAG, "No supported TCL AppBootPolicy provider detected");
+        return Result.unavailable();
+    }
+
+    private static JSONArray readPolicy(ContentResolver resolver, Uri uri) {
+        try (Cursor cursor = resolver.query(uri, PROJECTION, null, null, null)) {
+            if (cursor == null || !cursor.moveToFirst()) {
+                return null;
+            }
+            int contentIndex = cursor.getColumnIndex("config_content");
+            if (contentIndex < 0) {
+                return null;
+            }
+            String content = cursor.getString(contentIndex);
+            return content != null ? new JSONArray(content) : null;
+        } catch (Exception e) {
+            Log.d(TAG, "TCL policy provider unavailable at " + uri + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    static final class Result {
+        final boolean available;
+        final boolean success;
+        final boolean changed;
+        final String authority;
+
+        private Result(boolean available, boolean success, boolean changed, String authority) {
+            this.available = available;
+            this.success = success;
+            this.changed = changed;
+            this.authority = authority;
+        }
+
+        static Result success(String authority, boolean changed) {
+            return new Result(true, true, changed, authority);
+        }
+
+        static Result failed(String authority) {
+            return new Result(true, false, false, authority);
+        }
+
+        static Result unsupported(String authority) {
+            return new Result(true, false, false, authority);
+        }
+
+        static Result unavailable() {
+            return new Result(false, false, false, null);
+        }
+    }
+}

--- a/app/src/main/java/com/tpn/adbautoenable/TclBootPolicy.java
+++ b/app/src/main/java/com/tpn/adbautoenable/TclBootPolicy.java
@@ -1,0 +1,148 @@
+package com.tpn.adbautoenable;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+final class TclBootPolicy {
+    private static final String FOREGROUND_WHITELIST = "serviceStartForegroundWhiteList";
+    private static final String FOREGROUND_BLACKLIST = "serviceStartForegroundBlackList";
+    private static final String PROCESS_WHITELIST = "procWhiteList";
+    private static final String PACKAGE_NAMES = "packageName";
+    private static final int MAX_SUB_VERSION = 0x1ff;
+
+    private TclBootPolicy() {
+    }
+
+    static boolean supports(JSONArray policy) {
+        JSONObject root = policy.optJSONObject(0);
+        if (root == null) {
+            return false;
+        }
+        return root.has(FOREGROUND_WHITELIST) ^ root.has(FOREGROUND_BLACKLIST);
+    }
+
+    static boolean protect(JSONArray policy, String packageName) {
+        if (!supports(policy) || !isValidPackageName(packageName)) {
+            return false;
+        }
+
+        JSONObject root = policy.optJSONObject(0);
+        boolean changed;
+        if (root.has(FOREGROUND_WHITELIST)) {
+            changed = addPackage(root, FOREGROUND_WHITELIST, packageName);
+        } else {
+            changed = removePackage(root, FOREGROUND_BLACKLIST, packageName);
+        }
+
+        if (root.has(PROCESS_WHITELIST)) {
+            changed = addPackage(root, PROCESS_WHITELIST, packageName) || changed;
+        }
+
+        if (changed) {
+            advanceVersion(root);
+        }
+        return changed;
+    }
+
+    static boolean isProtected(JSONArray policy, String packageName) {
+        if (!supports(policy) || !isValidPackageName(packageName)) {
+            return false;
+        }
+
+        JSONObject root = policy.optJSONObject(0);
+        boolean foregroundProtected;
+        if (root.has(FOREGROUND_WHITELIST)) {
+            foregroundProtected = containsPackage(root, FOREGROUND_WHITELIST, packageName);
+        } else {
+            foregroundProtected = !containsPackage(root, FOREGROUND_BLACKLIST, packageName);
+        }
+
+        return foregroundProtected
+                && (!root.has(PROCESS_WHITELIST)
+                || containsPackage(root, PROCESS_WHITELIST, packageName));
+    }
+
+    private static boolean addPackage(JSONObject root, String key, String packageName) {
+        JSONObject section = root.optJSONObject(key);
+        if (section == null) {
+            return false;
+        }
+        JSONArray packages = section.optJSONArray(PACKAGE_NAMES);
+        if (packages == null) {
+            packages = new JSONArray();
+            try {
+                section.put(PACKAGE_NAMES, packages);
+            } catch (JSONException e) {
+                return false;
+            }
+        }
+        if (contains(packages, packageName)) {
+            return false;
+        }
+        packages.put(packageName);
+        return true;
+    }
+
+    private static boolean removePackage(JSONObject root, String key, String packageName) {
+        JSONObject section = root.optJSONObject(key);
+        JSONArray packages = section != null ? section.optJSONArray(PACKAGE_NAMES) : null;
+        if (packages == null) {
+            return false;
+        }
+
+        boolean changed = false;
+        for (int index = packages.length() - 1; index >= 0; index--) {
+            if (packageName.equals(packages.optString(index))) {
+                packages.remove(index);
+                changed = true;
+            }
+        }
+        return changed;
+    }
+
+    private static boolean containsPackage(JSONObject root, String key, String packageName) {
+        JSONObject section = root.optJSONObject(key);
+        JSONArray packages = section != null ? section.optJSONArray(PACKAGE_NAMES) : null;
+        return packages != null && contains(packages, packageName);
+    }
+
+    private static boolean contains(JSONArray values, String expected) {
+        for (int index = 0; index < values.length(); index++) {
+            if (expected.equals(values.optString(index))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void advanceVersion(JSONObject root) {
+        Object versionValue = root.opt("version");
+        Object subVersionValue = root.opt("subVersion");
+        if (!(versionValue instanceof Number) || !(subVersionValue instanceof Number)) {
+            return;
+        }
+
+        int version = ((Number) versionValue).intValue();
+        int subVersion = ((Number) subVersionValue).intValue();
+        if (version < 0 || subVersion < 0) {
+            return;
+        }
+        try {
+            if (subVersion < MAX_SUB_VERSION) {
+                root.put("subVersion", subVersion + 1);
+            } else {
+                root.put("version", version + 1);
+                root.put("subVersion", 0);
+            }
+        } catch (JSONException ignored) {
+            // The policy update remains valid when this optional version marker
+            // cannot be advanced. ContentProvider notifications still reload it.
+        }
+    }
+
+    private static boolean isValidPackageName(String packageName) {
+        return packageName != null
+                && packageName.matches("[A-Za-z][A-Za-z0-9_]*(\\.[A-Za-z][A-Za-z0-9_]*)+");
+    }
+}

--- a/app/src/main/java/com/tpn/adbautoenable/WebServer.java
+++ b/app/src/main/java/com/tpn/adbautoenable/WebServer.java
@@ -152,6 +152,19 @@ public class WebServer extends NanoHTTPD {
                         } else {
                             Log.w(TAG, "Failed to self-grant permission, user will need to grant manually");
                         }
+
+                        TclAutostartProtection.Result policy = TclAutostartProtection.apply(
+                                context.getContentResolver(),
+                                context.getPackageName()
+                        );
+                        if (policy.success) {
+                            boolean autoStartAllowed = adbHelper.ensureTclAutoStart(
+                                    deviceIP,
+                                    adbPort,
+                                    context.getPackageName()
+                            );
+                            Log.i(TAG, "TCL AUTO_START configured after pairing: " + autoStartAllowed);
+                        }
                     } catch (Exception e) {
                         Log.e(TAG, "Error during self-grant attempt", e);
                     }

--- a/app/src/test/java/com/tpn/adbautoenable/TclBootPolicyTest.java
+++ b/app/src/test/java/com/tpn/adbautoenable/TclBootPolicyTest.java
@@ -1,0 +1,60 @@
+package com.tpn.adbautoenable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class TclBootPolicyTest {
+    private static final String PACKAGE_NAME = "com.tpn.adbautoenable";
+
+    @Test
+    public void protectsT653WhitelistPolicy() throws Exception {
+        JSONArray policy = new JSONArray("[{"
+                + "\"version\":1,\"subVersion\":4,"
+                + "\"serviceStartForegroundWhiteList\":{\"packageName\":[\"com.tcl.system\"]},"
+                + "\"procWhiteList\":{\"packageName\":[\"com.tcl.guard\"]},"
+                + "\"unknown\":{\"preserved\":true}}]");
+
+        assertTrue(TclBootPolicy.protect(policy, PACKAGE_NAME));
+        assertTrue(TclBootPolicy.isProtected(policy, PACKAGE_NAME));
+        JSONObject root = policy.getJSONObject(0);
+        assertEquals(5, root.getInt("subVersion"));
+        assertTrue(root.getJSONObject("unknown").getBoolean("preserved"));
+    }
+
+    @Test
+    public void protectsBlacklistPolicy() throws Exception {
+        JSONArray policy = new JSONArray("[{"
+                + "\"serviceStartForegroundBlackList\":{\"packageName\":[\"com.tpn.adbautoenable\",\"other.app\"]}}]");
+
+        assertTrue(TclBootPolicy.protect(policy, PACKAGE_NAME));
+        assertTrue(TclBootPolicy.isProtected(policy, PACKAGE_NAME));
+        assertEquals("other.app", policy.getJSONObject(0)
+                .getJSONObject("serviceStartForegroundBlackList")
+                .getJSONArray("packageName").getString(0));
+    }
+
+    @Test
+    public void refusesAmbiguousPolicy() throws Exception {
+        JSONArray policy = new JSONArray("[{"
+                + "\"serviceStartForegroundWhiteList\":{\"packageName\":[]},"
+                + "\"serviceStartForegroundBlackList\":{\"packageName\":[]}}]");
+
+        assertFalse(TclBootPolicy.supports(policy));
+        assertFalse(TclBootPolicy.protect(policy, PACKAGE_NAME));
+    }
+
+    @Test
+    public void repeatedProtectionIsIdempotent() throws Exception {
+        JSONArray policy = new JSONArray("[{"
+                + "\"serviceStartForegroundWhiteList\":{\"packageName\":[\"com.tpn.adbautoenable\"]},"
+                + "\"procWhiteList\":{\"packageName\":[\"com.tpn.adbautoenable\"]}}]");
+
+        assertFalse(TclBootPolicy.protect(policy, PACKAGE_NAME));
+        assertTrue(TclBootPolicy.isProtected(policy, PACKAGE_NAME));
+    }
+}


### PR DESCRIPTION
Fix autostart on TCL TVs where Safety Guard blocks BOOT_COMPLETED even when receiver is enabled.

It detects TCL AppBootPolicy, adds app to required whitelist and sets AUTO_START appop after pairing. Tested on TCL 65C8K with T653 firmware, app starts correctly after reboot now.